### PR TITLE
Add force_load to linker flags on podspec

### DIFF
--- a/VoizeLibTorch-Lite.podspec
+++ b/VoizeLibTorch-Lite.podspec
@@ -21,7 +21,9 @@ Pod::Spec.new do |s|
 
     s.user_target_xcconfig = {
         'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
-        'CLANG_CXX_LIBRARY' => 'libc++'
+        'CLANG_CXX_LIBRARY' => 'libc++',
+        'OTHER_LDFLAGS[sdk=iphoneos*]' => '$(inherited) -force_load "$(PODS_ROOT)/VoizeLibTorch-Lite/LibTorchLite.xcframework/ios-arm64/libtorch_lite.a"',
+        'OTHER_LDFLAGS[sdk=iphonesimulator*]' => '$(inherited) -force_load "$(PODS_ROOT)/VoizeLibTorch-Lite/LibTorchLite.xcframework/ios-arm64_x86_64-simulator/libtorch_lite.a"'
     }
 
     s.library = ['c++', 'stdc++']


### PR DESCRIPTION
Without the `force_load` consumers of the pod will run into issues like

```
Could not find schema for aten::empty.memory_format ()
```

[The official LibTorch-Lite.podspec also does a `force_load`.](https://github.com/pytorch/pytorch/blob/v2.1.0/ios/LibTorch-Lite.podspec.template)
We should keep in mind that since we have a fat lib instead of individual ones and `force_load` is applied to all those libs where for the official podspec `force_load` is only applied on `libtorch.a` and `libtorch_cpu.a`.

References: 
- https://github.com/pytorch/pytorch/issues/48387 
- https://stackoverflow.com/questions/76575846/could-not-find-schema-for-atenempty-memory-format-in-libtorch